### PR TITLE
Fix ModuleNotFoundError by Updating Init Script

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,7 @@
+import os, sys
+_current_dir = os.path.dirname(__file__)
+if _current_dir not in sys.path:
+    sys.path.insert(0, _current_dir)
+
 from .utils import ensure_startup_dirs
 ensure_startup_dirs()


### PR DESCRIPTION
This pull request modifies the `src/__init__.py` file to add the current directory to the Python system path. This change addresses the `ModuleNotFoundError` for the 'prompts' module encountered during the Docker run command. By ensuring that the current directory is included in `sys.path`, the application can properly locate and import the required module, resolving the issue.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/k9ea282fl6n1](https://cosine.sh/tcswh35melzb/Query2CADAI/task/k9ea282fl6n1)
Author: phoenixAI.dev
