### PR TITLE
Fix missing module 'together' and update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,7 @@ torch
 transformers
 pillow
 git+https://github.com/openai/CLIP.git
+together>=1.5.16
+openai>=1.12.0
+packaging>=23.0
+pydantic>=2.0


### PR DESCRIPTION
This pull request addresses the ModuleNotFoundError caused by the absence of the 'together' module. The requirements.txt file has been updated to include 'together' along with other necessary dependencies: 'openai' and 'packaging', ensuring that the application can properly utilize functionalities that rely on these modules. This resolves the warnings and errors encountered when running the script.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/0mjlwmhgvuci](https://cosine.sh/tcswh35melzb/Query2CADAI/task/0mjlwmhgvuci)
Author: phoenixAI.dev
