### PR TITLE
Fix ImportError by Pinning timm Version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,11 @@ transformers
 pillow
 git+https://github.com/openai/CLIP.git
 together>=1.5.16
+timm==0.9.12  # pin to keep ImageNetInfo for transformers/gemma3n
+torch
+transformers
+pillow
+git+https://github.com/openai/CLIP.git
 openai>=1.12.0
 packaging>=23.0
 pydantic>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytest
 python-multipart
 pyyaml
 sentence-transformers
+timm==0.9.12  # pin to keep ImageNetInfo for transformers/gemma3n
 watchdog
 python-dotenv
 t2v_metrics
@@ -20,11 +21,6 @@ transformers
 pillow
 git+https://github.com/openai/CLIP.git
 together>=1.5.16
-timm==0.9.12  # pin to keep ImageNetInfo for transformers/gemma3n
-torch
-transformers
-pillow
-git+https://github.com/openai/CLIP.git
 openai>=1.12.0
 packaging>=23.0
 pydantic>=2.0


### PR DESCRIPTION
This PR addresses the ImportError encountered when running the application due to missing `ImageNetInfo` in the `timm.data` module. To resolve this, we have modified the `requirements.txt` file to pin the `timm` package to version 0.9.12. This ensures compatibility with the `transformers` library that relies on `ImageNetInfo` and avoids the import issue. 

With this change, the application should function correctly without encountering the import error.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/h98s3wgv4t6k](https://cosine.sh/tcswh35melzb/Query2CADAI/task/h98s3wgv4t6k)
Author: phoenixAI.dev
