### PR TITLE
Fix Image Input Type in Web UI

### DIFF
--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -91,7 +91,7 @@ def ui_main():
         gr.Markdown("# Query2CAD Humanoid Robot Pipeline")
         with gr.Row():
             with gr.Column():
-                image_input = gr.Image(type="bytes", label="Upload Robot Image")
+                image_input = gr.Image(type="filepath", label="Upload Robot Image")
                 prompt_hint = gr.Textbox(label="Prompt hint (optional)", value="")
                 extract_btn = gr.Button("Extract BOM")
             with gr.Column():


### PR DESCRIPTION
This pull request corrects the type of the image input in the web UI from 'bytes' to 'filepath'. The previous implementation caused a ValueError due to the unsupported 'bytes' type in Gradio's Image component. Changing it to 'filepath' resolves the issue, allowing users to upload images correctly.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/5yoc9y3738zq](https://cosine.sh/tcswh35melzb/Query2CADAI/task/5yoc9y3738zq)
Author: phoenixAI.dev
