### PR TITLE
Fix AttributeError in do_update_df function

### DIFF
--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -115,9 +115,9 @@ def ui_main():
             # Sync DataFrame to BOM dict
             pd = _lazy_import_pandas()
             if not pd or df is None:
-                return {}, gr.update()
+                return {}
             bom = df_to_bom(pd.DataFrame(df))
-            return bom, gr.update()
+            return bom
 
         def do_skeleton(bom):
             macro = get_skeleton_macro(bom)
@@ -130,7 +130,7 @@ def ui_main():
             return gr.update(value=path, visible=True), macro
 
         extract_btn.click(do_extract, [image_input, prompt_hint], [bom_df, state_bom, skeleton_btn, assembly_btn])
-        bom_df.change(do_update_df, [bom_df], [state_bom, gr.update()])
+        bom_df.change(do_update_df, [bom_df], [state_bom])
         skeleton_btn.click(lambda bom: do_skeleton(bom), [state_bom], [macro_download, state_macro])
         assembly_btn.click(lambda bom: do_assembly(bom), [state_bom], [macro_download, state_macro])
 


### PR DESCRIPTION
This pull request addresses an issue where an AttributeError occurred due to incorrect handling of outputs in the `do_update_df` function within `src/web_ui.py`. The function is modified to ensure that it returns the correct response type without attempting to reference `_id` on a dictionary object, which caused the error. 

### Changes made:
1. Removed unnecessary return of `gr.update()` when the DataFrame `df` is either not present or invalid.
2. Adjusted the `change` event attachment from `bom_df` to correctly reflect the changes without causing an error in the Gradio framework.

These changes fix the runtime error and help maintain the correct functionality of the UI.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/f5emn88hhha0](https://cosine.sh/tcswh35melzb/Query2CADAI/task/f5emn88hhha0)
Author: phoenixAI.dev
