### PR TITLE
Fix server binding and import error for Query2CADAI

### DIFF
--- a/src/prompts.py
+++ b/src/prompts.py
@@ -363,3 +363,34 @@ A rectangle
 """
 
     return prompt
+
+
+def get_parametric_prompt(user_query: str) -> str:
+    """
+    Build a parametric CAD macro request prompt based on user query.
+
+    Args:
+        user_query (str): The user's CAD task description.
+
+    Returns:
+        str: A prompt instructing the LLM to generate a parametric CAD macro.
+    """
+    return f"Generate a parametric CAD macro for: {user_query}"
+
+
+def get_explanation_prompt(macro_code: str) -> str:
+    """
+    Build a prompt asking the LLM to explain a FreeCAD macro step by step.
+
+    Args:
+        macro_code (str): The FreeCAD macro code to be explained.
+
+    Returns:
+        str: A prompt instructing the LLM to explain the macro code.
+    """
+    return (
+        "Explain step-by-step what the following FreeCAD macro does:\n\n"
+        "```python\n"
+        f"{macro_code}\n"
+        "```"
+    )

--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -142,7 +142,7 @@ def ui_main():
 if __name__ == "__main__":
     if HAS_GRADIO:
         utils.ensure_startup_dirs()
-        ui_main().launch()
+        ui_main().launch(server_name="0.0.0.0", server_port=int(os.getenv("PORT", 7860)))
     else:
         # logger is set up below
         logger = logging.getLogger("web_ui")
@@ -206,4 +206,4 @@ def launch_web_ui():
         thumbs_up.click(fn=feedback_good, inputs=[query, macro_out], outputs=None)
         thumbs_down.click(fn=feedback_bad, inputs=[query, macro_out], outputs=None)
 
-    demo.launch()
+    demo.launch(server_name="0.0.0.0", server_port=int(os.getenv("PORT", 7860)))


### PR DESCRIPTION
This pull request addresses two main issues when running the Query2CADAI application:

1. **ImportError Fix**: Previously, the application encountered an import error due to the missing `get_parametric_prompt` function in `src/prompts.py`. This function has now been added to facilitate generating CAD macro requests based on user queries.

2. **Server Binding**: The server launch in `src/web_ui.py` has been updated to bind to `0.0.0.0` instead of `localhost`, allowing access from external devices, which solves the issue of the browser not being able to connect to the server. This change ensures that the server listens on all available network interfaces.

With these changes, users should now be able to successfully access the application on http://127.0.0.1:7860 and avoid the connection refusal error.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/ae5b7bsyrn0s](https://cosine.sh/tcswh35melzb/Query2CADAI/task/ae5b7bsyrn0s)
Author: phoenixAI.dev
