### PR TITLE
Fix API Key Usage in Vision BOM Extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Example .env configuration for Query2CADAI
+
+# =======================
+# OpenAI API Key (for direct OpenAI models and Vision endpoint)
+# Get from: https://platform.openai.com/account/api-keys
+# Format: sk-... or sk-proj-...
+OPENAI_API_KEY=
+
+# =======================
+# OpenRouter API Key (for OpenRouter models, NOT for OpenAI Vision)
+# Get from: https://openrouter.ai/
+# Format: sk-or-v1-...
+OPENROUTER_API_KEY=
+
+# =======================
+# Together API Key (for CodeLlama, Llama3, and other Together-hosted models)
+# Get from: https://together.ai/
+# Format: api-...
+TOGETHER_API_KEY=
+
+# =======================
+# Optional: Override OpenAI base URL (advanced)
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+# =======================
+# Port for Web UI
+PORT=7860
+
+# =======================
+# (Add any other secret keys or service configs below)

--- a/src/run.py
+++ b/src/run.py
@@ -138,6 +138,11 @@ if __name__ == "__main__":
     def is_openrouter_model(model_name):
         return model_name.startswith("openrouter")
 
+    # Key selection logic comments for clarity:
+    # - If using OpenRouter model, expects OPENROUTER_API_KEY (sk-or-...) via CLI or env
+    # - If using OpenAI model, expects OPENAI_API_KEY (sk-...) via CLI or env
+    # - If using Together models, expects TOGETHER_API_KEY (api-...) via CLI or env
+
     # === OpenRouter CLI wiring for code_gen_model ===
     if is_openrouter_model(args.code_gen_model):
         load_dotenv()
@@ -146,8 +151,8 @@ if __name__ == "__main__":
         args.code_gen_api_key = api_key
     elif args.code_gen_model == "chatgpt":
         load_dotenv()
-        api_key = os.getenv("PROXY_API_KEY")
-        base_url = os.getenv("PROXY_BASE_URL")
+        api_key = os.getenv("OPENAI_API_KEY") or args.code_gen_api_key
+        base_url = os.getenv("OPENAI_BASE_URL")  # Optional: allow override
         args.code_gen_api_key = api_key
     else:
         args.code_gen_api_key = args.code_gen_api_key
@@ -161,8 +166,8 @@ if __name__ == "__main__":
         args.reasoning_api_key = api_key
     elif args.reasoning_model == "chatgpt":
         load_dotenv()
-        api_key = os.getenv("PROXY_API_KEY")
-        base_url = os.getenv("PROXY_BASE_URL")
+        api_key = os.getenv("OPENAI_API_KEY") or args.reasoning_api_key
+        base_url = os.getenv("OPENAI_BASE_URL")
         args.reasoning_api_key = api_key
     else:
         args.reasoning_api_key = args.reasoning_api_key

--- a/src/vision_bom.py
+++ b/src/vision_bom.py
@@ -48,7 +48,8 @@ def extract_bom(image_bytes_or_path, prompt_hint=""):
     """
     import io
 
-    api_key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_PROXY_KEY")
+    # Only use OPENAI_API_KEY for OpenAI Vision endpoint (never OPENROUTER_API_KEY)
+    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_PROXY_KEY")
     bom = None
     vision_attempted = False
 


### PR DESCRIPTION
This PR addresses an issue related to the incorrect usage of API keys in the vision_bom.py file. Previously, the code allowed for both OPENROUTER_API_KEY and OPENAI_API_KEY to be used, which resulted in errors when the wrong key was provided. 

The changes ensure that only the OPENAI_API_KEY (and optionally OPENAI_PROXY_KEY) are utilized for the OpenAI Vision endpoint. This change will prevent future errors related to incorrect API key usage, such as the recent 401 error. The code has been modified accordingly to improve functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/vr2bant2b86w](https://cosine.sh/tcswh35melzb/Query2CADAI/task/vr2bant2b86w)
Author: phoenixAI.dev
