### PR TITLE
Consolidate Query2CAD UI into a Unified Interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt
 
 # default to launching the web UI so no pyautogui / GUI automation is required
-CMD ["python", "-m", "src.web_ui"]
+CMD ["python", "-m", "src"]

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ This workflow takes you from a robot image to a FreeCAD macro for assembly or sk
 
 2. **Web UI**  
    - Launch with:  
-     `python -m src.web_ui`  
+     `python -m src`  
      This launches the unified Query2CAD Web Interface on [http://localhost:7860](http://localhost:7860) (by default). All features are now available via tabs:
        - **Pipeline**: Humanoid Robot Pipeline (image→BOM→macro, editable BOM, etc.)
        - **Macro**: Text→macro generator (natural language to FreeCAD macro)
        - **Chat**: Conversational Query2CAD AI, with voice input and chat history export
+
+   > **Note:** The all-in-one interface is always launched with `python -m src` (or via the `query2cadai` script if installed as a package). There is no longer a separate "pipeline-only" mode; all features are unified in this interface.
 
    **NEW: Text → Image → CAD Flow**
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,0 +1,12 @@
+"""Entrypoint for launching the unified Query2CAD Web UI."""
+
+def main():
+    # Ensure startup directories are present
+    from src.utils import ensure_startup_dirs
+    ensure_startup_dirs()
+    # Launch the unified Gradio Web UI (handles Gradio import errors internally)
+    from src.web_ui import launch_web_ui
+    launch_web_ui()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request addresses the issue of having multiple UIs for the Query2CAD application by introducing a single, unified web interface that combines all functionalities. The following changes were made:

- Modified the `Dockerfile` to launch the all-in-one UI by changing the command from `python -m src.web_ui` to `python -m src`.
- Updated the `README.md` file to reflect the new command for launching the UI and to clarify that the separate pipeline mode has been removed, emphasizing that all features are now available within the same interface.
- Added a new `src/__main__.py` file which serves as the entry point for launching the unified web UI, ensuring appropriate startup directories are initialized.

With these updates, users can now access the complete set of tools within a single interface, enhancing usability and streamlining the workflow.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/6390di3egif6](https://cosine.sh/tcswh35melzb/Query2CADAI/task/6390di3egif6)
Author: phoenixAI.dev
