### PR TITLE
Fix OpenAI Image Generation Prompt Length Handling

### DIFF
--- a/src/image_generator.py
+++ b/src/image_generator.py
@@ -65,6 +65,13 @@ def generate_image(prompt: str, size: str = "1024x1024", outdir: str = "results/
     except ImportError:
         raise RuntimeError("Pillow is required for placeholder image generation")
 
+    # Use the possibly truncated prompt for the placeholder image text, too
+    max_chars = int(os.environ.get("OPENAI_IMAGE_PROMPT_MAX_CHARS", 4000))
+    truncated_prompt = None
+    if len(prompt) > max_chars:
+        truncated_prompt = prompt[: max_chars - 3] + "..."
+    prompt_to_use = truncated_prompt if truncated_prompt is not None else prompt
+
     img = Image.new("RGB", (512, 512), (180, 180, 180))
     draw = ImageDraw.Draw(img)
     font = None
@@ -72,7 +79,7 @@ def generate_image(prompt: str, size: str = "1024x1024", outdir: str = "results/
         font = ImageFont.truetype("arial.ttf", 20)
     except Exception:
         font = ImageFont.load_default()
-    text = prompt.strip() or "(no prompt)"
+    text = prompt_to_use.strip() or "(no prompt)"
     lines = []
     max_width = 480
     # Simple word wrap

--- a/src/image_generator.py
+++ b/src/image_generator.py
@@ -24,10 +24,24 @@ def generate_image(prompt: str, size: str = "1024x1024", outdir: str = "results/
         try:
             import requests
             client = openai_mod.OpenAI(api_key=openai_api_key)
-            logging.info(f"Generating image for prompt: {prompt!r} (model: {image_model}, size: {size})")
+            # Truncate prompt if necessary
+            max_chars = int(os.environ.get("OPENAI_IMAGE_PROMPT_MAX_CHARS", 4000))
+            truncated_prompt = None
+            if len(prompt) > max_chars:
+                logging.info(
+                    f"Prompt length {len(prompt)} exceeds maximum {max_chars}, truncating."
+                )
+                truncated_prompt = prompt[: max_chars - 3] + "..."
+                logging.info(
+                    f"Using truncated prompt of length {len(truncated_prompt)} for image generation."
+                )
+
+            prompt_to_use = truncated_prompt if truncated_prompt is not None else prompt
+
+            logging.info(f"Generating image for prompt: {prompt_to_use!r} (model: {image_model}, size: {size})")
             response = client.images.generate(
                 model=image_model,
-                prompt=prompt,
+                prompt=prompt_to_use,
                 n=1,
                 size=size,
                 response_format="url"


### PR DESCRIPTION
This pull request addresses the issue of OpenAI image generation failing due to excessive prompt lengths by implementing a truncation feature. Now, if the prompt exceeds the defined maximum character limit (default is 4000), it gets truncated, and a warning is logged indicating the truncation. This improvement ensures that requests to the OpenAI API are valid and that errors are minimized. Additionally, the same prompt truncation is applied when generating placeholder images. This change enhances stability and usability for generating images with the image generator.

---

> This pull request was co-created with Cosine Genie

Original Task: [Query2CADAI/q5tf6w2n463i](https://cosine.sh/tcswh35melzb/Query2CADAI/task/q5tf6w2n463i)
Author: phoenixAI.dev
